### PR TITLE
worker: expose request.ip in status (if available)

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -289,6 +289,7 @@ class Worker extends EventEmitter {
         status.set('startTime', new Date());
         status.onStatus(() => {
             status.set('state', request.flora.state);
+            status.set('ip', request.ip || (request.connection ? request.connection.remoteAddress : null));
             status.set('method', request.method);
             status.set('url', request.url);
             status.set('httpVersion', request.httpVersion);


### PR DESCRIPTION
This enables implementation of "X-Forwarded-For" header