### PR TITLE
worker: refactored "state" flag (new "isActive" and "isAborted" flag for request-end-detection)

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -21,11 +21,12 @@ serverStatusEvent.fetch = () => {
 };
 
 function trackResponseEnd(request, response) {
-    function changeStatus(state) {
-        if (request.flora.state === 'aborted') {
+    function setEndStatus(state) {
+        if (request.flora.isAborted) {
             // remove connection (parent) from status as it's already closed:
             request.flora.status.parent.close();
         } else {
+            request.flora.isActive = false;
             request.flora.state = state;
         }
     }
@@ -33,12 +34,12 @@ function trackResponseEnd(request, response) {
     // inject our "end" method to track "sending" status:
     response._floraOrigEnd = response.end;
     response.end = (...args) => {
-        changeStatus('sending');
+        setEndStatus('sending');
         return response._floraOrigEnd(...args);
     };
 
     // track if someone pipes to us (no "end" call is guaranteed then):
-    response.once('pipe', () => changeStatus('piping'));
+    response.once('pipe', () => setEndStatus('piping'));
 }
 
 /**
@@ -276,6 +277,8 @@ class Worker extends EventEmitter {
     onRequest(request, response) {
         request.flora = request.flora || {};
         request.flora.startTime = process.hrtime();
+        request.flora.isActive = true; // false if response.end/pipe has been called
+        request.flora.isAborted = false; // true if client has closed connection
         request.flora.state = 'processing';
 
         request.connection.flora.isIdle = false;
@@ -301,6 +304,7 @@ class Worker extends EventEmitter {
         trackResponseEnd(request, response);
 
         response.on('finish', () => {
+            request.flora.isActive = false; // should already be false here by trackResponseEnd()
             request.flora.state = 'finished';
             status.close();
             request.connection.flora.isIdle = true;
@@ -316,13 +320,14 @@ class Worker extends EventEmitter {
         });
 
         response.on('close', () => {
-            if (request.flora.state !== 'processing') {
+            if (!request.flora.isActive) {
                 status.close();
                 if (request.connection.flora.isClosed) {
                     request.connection.flora.status.close();
                 }
             }
 
+            request.flora.isAborted = true;
             request.flora.state = 'aborted';
         });
     }


### PR DESCRIPTION
This enables "request.flora.state" to be overridden in the application to a more detailed "state" without breaking the logic here.